### PR TITLE
feat: extend to set the image pull policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ You can set the following values:
   IP address of `<release-name>-docassemble-redirect-service`.
 * `daImage`: default is `jhpyle/docassemble:latest`.  This is the
   image of **docassemble** that you want to use.
+* `daImagePullPolicy`: default is `Always`.  This is the image pull
+  policy for **docassemble** image.
 * `inClusterNGINX`: default is `true`.  By default, the chart runs
   NGINX inside the cluster in order to provide sticky session support
   for websockets communication.  The Live Help features use

--- a/docassemble/templates/backend.yaml
+++ b/docassemble/templates/backend.yaml
@@ -74,7 +74,7 @@ spec:
       containers:
       - name: docassemble
         image: {{ .Values.daImage }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.daImagePullPolicy }}
         volumeMounts:
         - name: config-data
           mountPath: /configdata

--- a/docassemble/templates/deployment.yaml
+++ b/docassemble/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       - name: docassemble
         image: {{ .Values.daImage }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.daImagePullPolicy }}
         envFrom:
           - secretRef:
               name: {{ .Release.Name }}-docassemble-secret

--- a/docassemble/values.yaml
+++ b/docassemble/values.yaml
@@ -7,6 +7,7 @@ busyboxImage: busybox:1.33
 timeZone: America/New_York
 #locale: en_US.UTF-8 UTF-8
 daImage: jhpyle/docassemble:latest
+daImagePullPolicy: Always
 daMonitorImage: jhpyle/docassemble-monitor:latest
 daHostname: localhost
 postgresStorage: 5Gi


### PR DESCRIPTION
Image pull policy is set to **Always** which causes it to takes time to start the container as the docker image is in large size(>3GB) and it does a docker pull each time(doesn't need to download each time but has to check the layer cache).

With this PR, it is possible to set the image pull policy.